### PR TITLE
Made the navbar sticky

### DIFF
--- a/src/components/Header/Header.jsx
+++ b/src/components/Header/Header.jsx
@@ -36,7 +36,7 @@ function Header() {
   }, []);
 
   return (
-    <header className='py-2 w-full rounded-xl items-center justify-center bg-blue-600 shadow'>
+    <header className='py-2 w-full rounded-xl items-center justify-center bg-blue-600 shadow sticky top-0 z-1'>
       <Container>
         <nav className='flex justify-between items-center'>
           <div className='mr-4'>


### PR DESCRIPTION
Making the navbar sticky is important as the users can  then access the essential links/pages faster without inhibiting the flow their experience ..........as it is quite a hassle to scroll back to top always for accessing the navbar.

Before:
![Screenshot (646)](https://github.com/chirantanbanik/Wellread/assets/142926792/454075b2-f8ba-4d1b-9af2-243e14659c9c)

After:
![Screenshot (645)](https://github.com/chirantanbanik/Wellread/assets/142926792/141dbd70-f262-4da4-992f-e81d9d36b6b7)

