### PR TITLE
Fix ReferenceError: string is not defined in AllPosts component

### DIFF
--- a/src/pages/AllPosts.jsx
+++ b/src/pages/AllPosts.jsx
@@ -1,10 +1,11 @@
+
 import React, { useState, useEffect } from 'react';
 import appwriteService from "../appwrite/config";
 import { Container, PostCard } from "../components";
 
 function AllPosts() {
   const [posts, setPosts] = useState([]);
-  const [searchTerm, setSearchTerm] = useState<string>("");
+  const [searchTerm, setSearchTerm] = useState("");
 
   useEffect(() => {
     appwriteService.getPosts([]).then((posts) => {


### PR DESCRIPTION
## Changes Made
- Fixed the ReferenceError by removing the incorrect type definition from `useState`.

## Reason for Changes
- The `string` type definition was causing a ReferenceError. Initializing `searchTerm` without specifying the type fixed the issue.

## Testing
- Manually tested the search functionality to ensure it works correctly.

